### PR TITLE
Refactor as a Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Alarm.com plugin for [Homebridge](https://github.com/nfarina/homebridge)
 5. Once you have a [WrapAPI](http://www.wrapapi.com) account, bookmark each one of API calls documented below so you can call them with your server API key.
 6. Update your configuration file. See sample-config.json snippet below.
 
-#WrapAPI Calls
+# WrapAPI Calls
 Bookmark each of the following calls on [WrapAPI](http://www.wrapapi.com). Once you do this and generate a server API key you can call the API
 * [initlogin](https://wrapapi.com/#/view/bryanbartow/alarmdotcom/initlogin/latest)
 * [login](https://wrapapi.com/#/view/bryanbartow/alarmdotcom/login/latest)
@@ -23,9 +23,9 @@ Configuration sample:
 
  ```
 {
-  "accessories": [
+  "platforms": [
     {
-        "accessory": "Alarmdotcom",
+        "platform": "Alarmdotcom",
         "name": "Security Panel",
         "username": "test@example.com",
         "password": "testpassword",
@@ -37,9 +37,9 @@ Configuration sample:
 
 ```
 
-Fields: 
+Fields:
 
-* "accessory": Must always be "Alarmdotcom" (required)
+* "platform": Must always be "Alarmdotcom" (required)
 * "name": Can be anything (required)
 * "username": Alarm.com login username, same as app (required)
 * "password": Alarm.com login password, same as app (required)

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = homebridge => {
         .on('set', (state, callback) => nodeify(this.setState(state), callback));
     }
 
-    getState(callback) {
+    getState() {
       return this.login().then(result => result.currentState);
     }
 

--- a/index.js
+++ b/index.js
@@ -4,8 +4,10 @@ const nodeify = require('nodeify');
 const rp = require('request-promise');
 
 module.exports = homebridge => {
+  const Accessory = homebridge.platformAccessory;
   const Characteristic = homebridge.hap.Characteristic;
   const Service = homebridge.hap.Service;
+  const UUIDGen = homebridge.hap.uuid;
 
   const TargetStateConfiguration = {
     [Characteristic.SecuritySystemTargetState.STAY_ARM]: {
@@ -30,69 +32,82 @@ module.exports = homebridge => {
     },
   };
 
-  class AlarmcomAccessory {
-    constructor(log, config) {
-      this.log = log;
-      this.name = config.name;
-      this.username = config.username;
-      this.password = config.password;
-      this.apiKey = config.apiKey;
-      this.apiUsername = config.apiUsername;
+  class ADCPlatform {
+     constructor(log, config) {
+       this.api = new ADCWrapAPI(log, config);
+       this.log = log;
+       this.name = config.name;
+     }
 
-      this.service = new Service.SecuritySystem(this.name);
+    accessories(callback) {
+      callback([
+        new ADCSecuritySystemAccessory(this, this.name),
+      ]);
+    }
+  }
 
-      this.service
+  class ADCSecuritySystemAccessory extends Accessory {
+    constructor(platform, name) {
+      const displayName = `Alarm.com ${name}`;
+      const uuid = UUIDGen.generate('alarmdotcom.security-system');
+      super(displayName, uuid);
+
+      // Homebridge reqiures these.
+      this.name = displayName;
+      this.uuid_base = uuid;
+
+      this.api = platform.api;
+      this.log = platform.log;
+
+      this.addService(new Service.SecuritySystem(name));
+
+      this.getService(Service.SecuritySystem)
         .getCharacteristic(Characteristic.SecuritySystemCurrentState)
         .on('get', callback => nodeify(this.getState(), callback));
 
-      this.service
+      this.getService(Service.SecuritySystem)
         .getCharacteristic(Characteristic.SecuritySystemTargetState)
         .on('get', callback => nodeify(this.getState(), callback))
         .on('set', (state, callback) => nodeify(this.setState(state), callback));
     }
 
     getState() {
-      return this.login().then(result => result.currentState);
+      return this.api.login().then(session => session.currentState);
     }
 
     setState(targetState) {
-      return this.login().then(result => {
+      return this.api.login().then(session => {
         const targetStateConfig = TargetStateConfiguration[targetState];
+        this.log(`Setting security system to \`${targetStateConfig.name}\`.`);
 
-        this.log('Setting state to `%s`.', targetStateConfig.name);
-
-        return this.send(targetStateConfig.apiVerb, {
-          sessionUrl: result.sessionUrl,
-          username: this.username,
-          password: this.password,
-        }).then(() => {
-          this.log(`Alarm set to \`${targetStateConfig.name}\`.`);
-
-          const currentState = targetStateConfig.currentState;
-
-          this.service.setCharacteristic(
+        return session.send(targetStateConfig.apiVerb).then(() => {
+          this.getService(Service.SecuritySystem).setCharacteristic(
             Characteristic.SecuritySystemCurrentState,
-            currentState
+            targetStateConfig.currentState
           );
-
-          return currentState;
         });
       });
     }
 
+    getServices() {
+      return this.services;
+    }
+  }
+
+  class ADCWrapAPI {
+    constructor(log, config) {
+      this.log = log;
+      this.config = config;
+    }
+
     login() {
-      this.log('Getting `sessionUrl`.');
-
       return this.send('initlogin').then(json => {
-        const sessionUrl = json.data.sessionUrl;
-
-        this.log('Logging in.');
-
-        return this.send('login', {
-          sessionUrl,
-          username: this.username,
-          password: this.password,
-        }).then(json => {
+        const sessionParams = {
+          sessionUrl: json.data.sessionUrl,
+          username: this.config.username,
+          password: this.config.password,
+        };
+        return this.send('login', sessionParams).then(json => {
           switch (json.data.alarmState) {
             case 'Disarmed':
               return Characteristic.SecuritySystemCurrentState.DISARMED;
@@ -105,8 +120,8 @@ module.exports = homebridge => {
           }
         }).then(currentState => {
           return {
-            sessionUrl,
             currentState,
+            send: action => this.send(action, sessionParams),
           };
         });
       });
@@ -115,8 +130,8 @@ module.exports = homebridge => {
     send(action, params) {
       return rp({
         json: true,
-        qs: Object.assign({wrapAPIKey: this.apiKey}, params),
-        url: `https://wrapapi.com/use/${this.apiUsername}/alarmdotcom/${action}/0.0.2`,
+        qs: Object.assign({wrapAPIKey: this.config.apiKey}, params),
+        url: `https://wrapapi.com/use/${this.config.apiUsername}/alarmdotcom/${action}/0.0.2`,
       }).catch(reason => {
         this.log(
           'Error in `%s` (status code %s): %s',
@@ -127,11 +142,7 @@ module.exports = homebridge => {
         throw reason.error;
       });
     }
-
-    getServices() {
-      return [this.service];
-    }
   }
 
-  homebridge.registerAccessory('homebridge-alarmdotcom', 'Alarmdotcom', AlarmcomAccessory);
+  homebridge.registerPlatform('homebridge-alarmdotcom', 'Alarmdotcom', ADCPlatform);
 };


### PR DESCRIPTION
Refactors the Alarm.com Homebridge plugin to expose a platform instead of a single accessor, as proposed in #10. Currently, the platform only exposes a single security system accessory and behaves almost the same as before. However, this sets the stage for implementing accessories for other integrations supported by Alarm.com.

As far as behavior changes, this pull request removes some of the verbose logging for logic that is — at this point — pretty reliable and unnecessary. I've abstracted the WrapAPI request logic so that it can be used by all of the accessories (and not only the security system). This also helped me realize that a good future enhancement would be to reuse `sessionUrl` tokens whenever possible, which will improve responsiveness of commands.
