### PR TITLE
Simpler WrapAPI Params

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = homebridge => {
       const uuid = UUIDGen.generate('alarmdotcom.security-system');
       super(displayName, uuid);
 
-      // Homebridge reqiures these.
+      // Homebridge requires these.
       this.name = displayName;
       this.uuid_base = uuid;
 

--- a/index.js
+++ b/index.js
@@ -102,12 +102,12 @@ module.exports = homebridge => {
 
     login() {
       return this.send('initlogin').then(json => {
-        const sessionParams = {
-          sessionUrl: json.data.sessionUrl,
+        const sessionUrl = json.data.sessionUrl;
+        return this.send('login', {
+          sessionUrl,
           username: this.config.username,
           password: this.config.password,
-        };
-        return this.send('login', sessionParams).then(json => {
+        }).then(json => {
           switch (json.data.alarmState) {
             case 'Disarmed':
               return Characteristic.SecuritySystemCurrentState.DISARMED;
@@ -121,7 +121,7 @@ module.exports = homebridge => {
         }).then(currentState => {
           return {
             currentState,
-            send: action => this.send(action, sessionParams),
+            send: action => this.send(action, {sessionUrl}),
           };
         });
       });


### PR DESCRIPTION
Currently, the plugin sends both `username` and `password` for every action. This is unnecessary and might be less secure, so this changes the plugin to only send the user credentials when authenticating a session.
