### PR TITLE
Add Locks & Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Bookmark each of the following calls on [WrapAPI](https://www.wrapapi.com). Once
 * [disarm](https://wrapapi.com/#/view/bryanbartow/alarmdotcom/disarm/latest)
 * [armstay](https://wrapapi.com/#/view/bryanbartow/alarmdotcom/armstay/latest)
 * [armaway](https://wrapapi.com/#/view/bryanbartow/alarmdotcom/armaway/latest)
+* [locks](https://wrapapi.com/#/view/yungsters/alarmdotcom/locks/latest)
+* [lock](https://wrapapi.com/#/view/yungsters/alarmdotcom/lock/latest)
+* [unlock](https://wrapapi.com/#/view/yungsters/alarmdotcom/unlock/latest)
 
 # Configuration
 

--- a/index.js
+++ b/index.js
@@ -46,10 +46,10 @@ module.exports = homebridge => {
     }
   }
 
-  class ADCSecuritySystemAccessory extends Accessory {
-    constructor(platform, name) {
+  class ADCAccessory extends Accessory {
+    constructor(platform, name, type) {
       const displayName = `Alarm.com ${name}`;
-      const uuid = UUIDGen.generate('alarmdotcom.security-system');
+      const uuid = UUIDGen.generate(`alarmdotcom.${type}`);
       super(displayName, uuid);
 
       // Homebridge requires these.
@@ -58,6 +58,16 @@ module.exports = homebridge => {
 
       this.api = platform.api;
       this.log = platform.log;
+    }
+
+    getServices() {
+      return this.services;
+    }
+  }
+
+  class ADCSecuritySystemAccessory extends ADCAccessory {
+    constructor(platform, name) {
+      super(platform, name, 'security-system');
 
       this.addService(new Service.SecuritySystem(name));
 
@@ -87,10 +97,6 @@ module.exports = homebridge => {
           );
         });
       });
-    }
-
-    getServices() {
-      return this.services;
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ module.exports = homebridge => {
 
   const TargetStateConfiguration = {
     [Characteristic.SecuritySystemTargetState.STAY_ARM]: {
-      apiVerb: 'armstay',
+      apiVerb: 'armstay/0.0.3',
       currentState: Characteristic.SecuritySystemCurrentState.STAY_ARM,
       name: 'Armed Stay',
     },
     [Characteristic.SecuritySystemTargetState.AWAY_ARM]: {
-      apiVerb: 'armaway',
+      apiVerb: 'armaway/0.0.3',
       currentState: Characteristic.SecuritySystemCurrentState.AWAY_ARM,
       name: 'Armed Away',
     },
@@ -26,7 +26,7 @@ module.exports = homebridge => {
       name: 'Armed Night',
     },
     [Characteristic.SecuritySystemTargetState.DISARM]: {
-      apiVerb: 'disarm',
+      apiVerb: 'disarm/0.0.3',
       currentState: Characteristic.SecuritySystemCurrentState.DISARMED,
       name: 'Disarmed',
     },
@@ -101,9 +101,9 @@ module.exports = homebridge => {
     }
 
     login() {
-      return this.send('initlogin').then(json => {
+      return this.send('initlogin/0.0.3').then(json => {
         const sessionUrl = json.data.sessionUrl;
-        return this.send('login', {
+        return this.send('login/0.0.3', {
           sessionUrl,
           username: this.config.username,
           password: this.config.password,
@@ -128,14 +128,18 @@ module.exports = homebridge => {
     }
 
     send(action, params) {
+      if (!action.match(/^\w+\/\d+\.\d+\.\d+$/)) {
+        throw new Error(`Invalid \`action\` supplied: ${action}`);
+      }
+      const apiPath = `${this.config.apiUsername}/alarmdotcom/${action}`;
       return rp({
         json: true,
         qs: Object.assign({wrapAPIKey: this.config.apiKey}, params),
-        url: `https://wrapapi.com/use/${this.config.apiUsername}/alarmdotcom/${action}/0.0.3`,
+        url: `https://wrapapi.com/use/${apiPath}`,
       }).catch(reason => {
         this.log(
           'Error in `%s` (status code %s): %s',
-          action,
+          apiPath,
           reason.response.statusCode,
           reason.error
         );

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = homebridge => {
   const Service = homebridge.hap.Service;
   const UUIDGen = homebridge.hap.uuid;
 
-  const TargetStateConfiguration = {
+  const TargetSecuritySystemStateConfig = {
     [Characteristic.SecuritySystemTargetState.STAY_ARM]: {
       apiVerb: 'armstay/0.0.3',
       currentState: Characteristic.SecuritySystemCurrentState.STAY_ARM,
@@ -77,7 +77,7 @@ module.exports = homebridge => {
 
     setState(targetState) {
       return this.api.login().then(session => {
-        const targetStateConfig = TargetStateConfiguration[targetState];
+        const targetStateConfig = TargetSecuritySystemStateConfig[targetState];
         this.log(`Setting security system to \`${targetStateConfig.name}\`.`);
 
         return session.send(targetStateConfig.apiVerb).then(() => {

--- a/index.js
+++ b/index.js
@@ -136,15 +136,27 @@ module.exports = homebridge => {
         json: true,
         qs: Object.assign({wrapAPIKey: this.config.apiKey}, params),
         url: `https://wrapapi.com/use/${apiPath}`,
-      }).catch(reason => {
-        this.log(
-          'Error in `%s` (status code %s): %s',
-          apiPath,
-          reason.response.statusCode,
-          reason.error
-        );
-        throw reason.error;
-      });
+      }).then(
+        json => {
+          if (!json.success) {
+            const errorMessage =
+              `Request \`${apiPath}\` was unsuccessful:\n` +
+              json.messages.map(message => ' - ' + message).join('\n');
+            this.log(errorMessage);
+            throw new Error(errorMessage);
+          }
+          return json;
+        },
+        reason => {
+          this.log(
+            'Error in `%s` (status code %s): %s',
+            apiPath,
+            reason.response.statusCode,
+            reason.error
+          );
+          throw reason.error;
+        }
+      );
     }
   }
 


### PR DESCRIPTION
Adds support for controlling locks associated with an Alarm.com account to the plugin.

This also adds some primitive caching of the session (with a 60s timer) and responses (locks with a TTL of 5s) which should make most HomeKit user interfaces significantly more responsive.

Fixes #10 and partially addresses #13.
