### PR TITLE
Prevent fataling security system if finding locks fatal.

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,11 @@ module.exports = homebridge => {
         .then(session => session.send('locks/0.1.0'))
         .then(json => json.data.locks.map(
           lock => new ADCLockAccessory(this, lock)
-        ));
+        ))
+        .catch(error => {
+          this.log('Error while getting lock devices: %s', error);
+          return [];
+        });
     }
   }
 


### PR DESCRIPTION
This will fix the bug in 0.5.0. I'll work on a fix for the WrapAPI endpoint that will prevent the log spew.
