### PR TITLE
Updated 'locks' api location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Bookmark each of the following calls on [WrapAPI](https://www.wrapapi.com). Once
 * [disarm](https://wrapapi.com/#/view/bryanbartow/alarmdotcom/disarm/latest)
 * [armstay](https://wrapapi.com/#/view/bryanbartow/alarmdotcom/armstay/latest)
 * [armaway](https://wrapapi.com/#/view/bryanbartow/alarmdotcom/armaway/latest)
-* [locks](https://wrapapi.com/#/view/yungsters/alarmdotcom/locks/latest)
+* [locks](https://wrapapi.com/#/view/andrewmattie/alarmdotcom/locks/latest)
 * [lock](https://wrapapi.com/#/view/yungsters/alarmdotcom/lock/latest)
 * [unlock](https://wrapapi.com/#/view/yungsters/alarmdotcom/unlock/latest)
 * [lights](https://wrapapi.com/#/view/rcaslis/alarmdotcom/lights/latest)


### PR DESCRIPTION
Updated 'locks' api location fixes the issue of not being able to get the list of locks. 